### PR TITLE
Add alpha parameter to ppi_mean_ci call

### DIFF
--- a/ppi_py/ppi.py
+++ b/ppi_py/ppi.py
@@ -179,6 +179,7 @@ def ppi_mean_ci(
             Y,
             Yhat,
             Yhat_unlabeled,
+            alpha=alpha,
             lhat=lhat,
             coord=coord,
             w=w,


### PR DESCRIPTION
The `alpha` parameter did not propagate when `lhat=None`.
This PR is a quickfix to make sure it does.