### PR TITLE
Update references and DOI to published article

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ The repository currently implements the methods developed in the following paper
 
 [Prediction-Powered Bootstrap](https://arxiv.org/abs/2405.18379)
 
-[The Mixed Subjects Design: Treating Large Language Models as  (Potentially) Informative Observations](https://osf.io/preprints/socarxiv/j3bnt)
+[The Mixed Subjects Design: Treating Large Language Models as Potentially Informative Observations](https://doi.org/10.1177/00491241251326865)

--- a/examples/power_analysis.ipynb
+++ b/examples/power_analysis.ipynb
@@ -26,7 +26,7 @@
     "References \n",
     "* [1] Angelopoulos, A. N., Bates, S., Fannjiang, C., Jordan, M. I., & Zrnic, T. (2023). Prediction-powered inference. Science, 382(6671), 669-674.  https://www.science.org/doi/full/10.1126/science.adi6000 \n",
     "* [2] Angelopoulos, A. N., Duchi, J. C., & Zrnic, T. (2023). PPI++: Efficient prediction-powered inference. https://arxiv.org/abs/2311.01453\n",
-    "* [3] Broska, D., Howes, M., & van Loon, A. (2024). The Mixed Subjects Design: Treating Large Language Models as  (Potentially) Informative Observations. https://doi.org/10.31235/osf.io/j3bnt\n",
+    "* [3] Broska, D., Howes, M., & van Loon, A. (2025). The Mixed Subjects Design: Treating Large Language Models as Potentially Informative Observations. Sociological Methods & Research. https://doi.org/10.1177/00491241251326865\n",
     "\n"
    ]
   },


### PR DESCRIPTION
Hi all, 

Our article that introduces the PPI correlation and PPI power analysis has now been published in [Sociological Methods and Research](https://journals.sagepub.com/doi/10.1177/00491241251326865). I have updated the title and DOI in the README and the examples/power_analysis.ipynb accordingly. Could you merge the requested changes? Thank you!

All the best, 
David